### PR TITLE
Fix incorrect package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install [ESLint](https://www.github.com/eslint/eslint) either locally or globall
 
 If you installed `ESLint` globally, you have to install the plugin globally too. Otherwise, install it locally.
 
-    $ npm install eslint-plugin-destructuring
+    $ npm install eslint-plugin-switch-case
 
 # Configuration
 


### PR DESCRIPTION
readme says to use "npm install eslint-plugin-destructuring"
package name is "eslint-plugin-switch-case"